### PR TITLE
fixed browser tab displaying cohort id

### DIFF
--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "Cohorts ##{@cohort.id}" %>
+<%= content_for :title, "#{@cohort.cohort_name} Cohort" %>
 <%= turbo_stream_from @cohort %>
 
 <div class="container px-4 mx-auto my-8">


### PR DESCRIPTION
# Submitting Pull Request

### Ticket

ID number: 42

Branch name: cohort-browser-tab

Description: made the browser tab title display the name of the cohort rather than the id

Link to ticket: https://www.notion.so/Student-Application-Dashboard-1333c4b5cd684d179b86f03fc61cab4f?p=fc36b88c44d043a08079270686fd7a5a&pm=s

### Notes

Notes for the reviewer:

Contributors: Logan
